### PR TITLE
refactor(analyzers): extract llm helpers to llm-utils

### DIFF
--- a/src/__tests__/llm.test.ts
+++ b/src/__tests__/llm.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LLMAnalyzer } from '../analyzers/llm';
+import { extractJSON, findTextRange } from '../analyzers/llm-utils';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 describe('LLMAnalyzer', () => {
@@ -30,50 +31,47 @@ describe('LLMAnalyzer', () => {
   });
 
   describe('extractJSON', () => {
-    // Access private method for direct testing
-    const extract = (text: string) => (analyzer as any).extractJSON(text);
-
     it('should parse plain JSON', () => {
-      const result = extract('{"issues": []}');
+      const result = extractJSON('{"issues": []}');
       expect(result).toEqual({ issues: [] });
     });
 
     it('should parse code-fenced JSON with language tag', () => {
-      const result = extract('```json\n{"issues": []}\n```');
+      const result = extractJSON('```json\n{"issues": []}\n```');
       expect(result).toEqual({ issues: [] });
     });
 
     it('should parse code-fenced JSON without language tag', () => {
-      const result = extract('```\n{"key": "value"}\n```');
+      const result = extractJSON('```\n{"key": "value"}\n```');
       expect(result).toEqual({ key: 'value' });
     });
 
     it('should throw on invalid JSON', () => {
-      expect(() => extract('not json at all')).toThrow();
+      expect(() => extractJSON('not json at all')).toThrow();
     });
 
     it('should handle JSON with surrounding whitespace', () => {
-      const result = extract('  \n{"ok": true}\n  ');
+      const result = extractJSON('  \n{"ok": true}\n  ');
       expect(result).toEqual({ ok: true });
     });
 
     it('should handle JSON with leading preamble text', () => {
-      const result = extract('Here is the analysis:\n{"issues": []}');
+      const result = extractJSON('Here is the analysis:\n{"issues": []}');
       expect(result).toEqual({ issues: [] });
     });
 
     it('should handle JSON with trailing text', () => {
-      const result = extract('{"issues": []}\nHope this helps!');
+      const result = extractJSON('{"issues": []}\nHope this helps!');
       expect(result).toEqual({ issues: [] });
     });
 
     it('should handle JSON inside code fence with preamble text', () => {
-      const result = extract('```json\nHere is the analysis:\n{"issues": []}\n```');
+      const result = extractJSON('```json\nHere is the analysis:\n{"issues": []}\n```');
       expect(result).toEqual({ issues: [] });
     });
 
     it('should handle nested objects', () => {
-      const result = extract('{"a": {"b": [1, 2, 3]}}');
+      const result = extractJSON('{"a": {"b": [1, 2, 3]}}');
       expect(result).toEqual({ a: { b: [1, 2, 3] } });
     });
 
@@ -84,19 +82,19 @@ describe('LLMAnalyzer', () => {
           { "text": "second" }
         ]
       }`;
-      const result = extract(malformed);
+      const result = extractJSON(malformed);
       expect(result).toEqual({
         issues: [{ text: 'first' }, { text: 'second' }],
       });
     });
 
     it('should prefer balanced JSON object over trailing prose with braces', () => {
-      const result = extract('{"ok": true}\nNote: use {care} when editing files.');
+      const result = extractJSON('{"ok": true}\nNote: use {care} when editing files.');
       expect(result).toEqual({ ok: true });
     });
 
     it('should accept JSONC-style comments and trailing commas', () => {
-      const result = extract(`{
+      const result = extractJSON(`{
         // comment
         "items": [
           1,
@@ -108,12 +106,9 @@ describe('LLMAnalyzer', () => {
   });
 
   describe('findTextRange', () => {
-    const find = (doc: TextDocument, text: string) =>
-      (analyzer as any).findTextRange(doc, text);
-
     it('should find exact match with column offsets', () => {
       const doc = makeDoc('first line\nsecond line\nthird line');
-      const r = find(doc, 'second line');
+      const r = findTextRange(doc, 'second line');
       expect(r.line).toBe(1);
       expect(r.startChar).toBe(0);
       expect(r.endChar).toBe('second line'.length);
@@ -121,7 +116,7 @@ describe('LLMAnalyzer', () => {
 
     it('should find partial match with column offsets', () => {
       const doc = makeDoc('the quick brown fox\njumps over\nthe lazy dog');
-      const r = find(doc, 'brown fox');
+      const r = findTextRange(doc, 'brown fox');
       expect(r.line).toBe(0);
       expect(r.startChar).toBe('the quick '.length);
       expect(r.endChar).toBe('the quick brown fox'.length);
@@ -129,7 +124,7 @@ describe('LLMAnalyzer', () => {
 
     it('should return line 0 full line when no match found', () => {
       const doc = makeDoc('hello world');
-      const r = find(doc, 'nonexistent text that does not appear');
+      const r = findTextRange(doc, 'nonexistent text that does not appear');
       expect(r.line).toBe(0);
       expect(r.startChar).toBe(0);
       expect(r.endChar).toBe('hello world'.length);
@@ -137,7 +132,7 @@ describe('LLMAnalyzer', () => {
 
     it('should be case-insensitive', () => {
       const doc = makeDoc('Hello World\nGoodbye');
-      const r = find(doc, 'hello world');
+      const r = findTextRange(doc, 'hello world');
       expect(r.line).toBe(0);
       expect(r.startChar).toBe(0);
       expect(r.endChar).toBe('hello world'.length);
@@ -145,13 +140,13 @@ describe('LLMAnalyzer', () => {
 
     it('should handle empty text', () => {
       const doc = makeDoc('hello');
-      const r = find(doc, '');
+      const r = findTextRange(doc, '');
       expect(r.line).toBe(0);
     });
 
     it('should fall back to word-level partial match with column offsets', () => {
       const doc = makeDoc('line one\nline two with important word\nline three');
-      const r = find(doc, 'important word in a different sentence');
+      const r = findTextRange(doc, 'important word in a different sentence');
       expect(r.line).toBe(1);
       expect(r.startChar).toBe('line two with '.length);
       expect(r.endChar).toBe('line two with '.length + 'important'.length);

--- a/src/analyzers/llm-utils.ts
+++ b/src/analyzers/llm-utils.ts
@@ -1,0 +1,229 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+/**
+ * Extract JSON from an LLM response that may be wrapped in markdown code fences
+ * or contain leading/trailing non-JSON text.
+ */
+export function extractJSON<T>(text: string): T {
+  const candidates = buildJSONCandidates(text);
+  let lastError: unknown;
+
+  for (const candidate of candidates) {
+    const normalized = candidate.trim();
+    if (!normalized) {
+      continue;
+    }
+
+    try {
+      return JSON.parse(normalized) as T;
+    } catch (error) {
+      lastError = error;
+    }
+
+    const repaired = repairCommonJSONIssues(normalized);
+    if (repaired !== normalized) {
+      try {
+        return JSON.parse(repaired) as T;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+  }
+
+  throw (lastError instanceof Error ? lastError : new Error('JSON parse error'));
+}
+
+function buildJSONCandidates(text: string): string[] {
+  const trimmed = text.trim();
+  const candidates: string[] = [];
+
+  const pushCandidate = (value: string | undefined): void => {
+    const normalized = value?.trim();
+    if (!normalized || candidates.includes(normalized)) {
+      return;
+    }
+    candidates.push(normalized);
+  };
+
+  pushCandidate(trimmed);
+
+  const jsonFenced: string[] = [];
+  const genericFenced: string[] = [];
+  const fencePattern = /```([a-zA-Z0-9_-]+)?\s*\n?([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = fencePattern.exec(trimmed)) !== null) {
+    const language = (match[1] || '').toLowerCase();
+    const content = match[2]?.trim();
+    if (!content) {
+      continue;
+    }
+
+    if (language === 'json') {
+      jsonFenced.push(content);
+    } else {
+      genericFenced.push(content);
+    }
+  }
+
+  for (const block of jsonFenced) {
+    pushCandidate(block);
+  }
+  for (const block of genericFenced) {
+    pushCandidate(block);
+  }
+
+  const snapshot = candidates.slice();
+  for (const candidate of snapshot) {
+    pushCandidate(extractBalancedJSONObject(candidate));
+  }
+
+  return candidates;
+}
+
+function extractBalancedJSONObject(value: string): string | undefined {
+  const start = value.indexOf('{');
+  if (start === -1) {
+    return undefined;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < value.length; i++) {
+    const ch = value[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+      continue;
+    }
+
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return value.slice(start, i + 1);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function repairCommonJSONIssues(input: string): string {
+  let result = input
+    .replace(/\uFEFF/g, '')
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/.*$/gm, '')
+    .replace(/,\s*([}\]])/g, '$1');
+
+  for (let i = 0; i < 4; i++) {
+    const position = getParseErrorPosition(result);
+    if (position === undefined || position <= 0 || position >= result.length) {
+      break;
+    }
+
+    const previous = findPreviousNonWhitespace(result, position - 1);
+    const current = findNextNonWhitespace(result, position);
+    if (previous === undefined || current === undefined) {
+      break;
+    }
+
+    const valueEnding = /[\]"0-9eElrtf}]/.test(previous);
+    const valueStarting = /[[{"\-0-9tfn]/.test(current);
+    if (!valueEnding || !valueStarting) {
+      break;
+    }
+
+    result = result.slice(0, position) + ',' + result.slice(position);
+  }
+
+  return result;
+}
+
+function getParseErrorPosition(text: string): number | undefined {
+  try {
+    JSON.parse(text);
+    return undefined;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/position\s+(\d+)/i);
+    if (!match) {
+      return undefined;
+    }
+
+    const parsed = Number.parseInt(match[1], 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+}
+
+function findPreviousNonWhitespace(text: string, index: number): string | undefined {
+  for (let i = index; i >= 0; i--) {
+    if (!/\s/.test(text[i])) {
+      return text[i];
+    }
+  }
+  return undefined;
+}
+
+function findNextNonWhitespace(text: string, index: number): string | undefined {
+  for (let i = index; i < text.length; i++) {
+    if (!/\s/.test(text[i])) {
+      return text[i];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Find the location of a piece of text in the document, returning line and column offsets.
+ */
+export function findTextRange(
+  doc: TextDocument,
+  text: string,
+): { line: number; startChar: number; endChar: number } {
+  if (!text) return { line: 0, startChar: 0, endChar: doc.getText().split('\n')[0]?.length || 0 };
+
+  const lines = doc.getText().split('\n');
+  const lowerText = text.toLowerCase();
+
+  for (let i = 0; i < lines.length; i++) {
+    const col = lines[i].toLowerCase().indexOf(lowerText);
+    if (col !== -1) {
+      return { line: i, startChar: col, endChar: col + text.length };
+    }
+  }
+
+  const words = lowerText.split(/\s+/).filter(w => w.length > 3).slice(0, 5);
+  for (let i = 0; i < lines.length; i++) {
+    const lowerLine = lines[i].toLowerCase();
+    for (const word of words) {
+      const col = lowerLine.indexOf(word);
+      if (col !== -1) {
+        return { line: i, startChar: col, endChar: col + word.length };
+      }
+    }
+  }
+
+  return { line: 0, startChar: 0, endChar: lines[0]?.length || 0 };
+}

--- a/src/analyzers/llm.ts
+++ b/src/analyzers/llm.ts
@@ -8,6 +8,7 @@ import {
   LLMCombinedAnalysisResponse,
   CustomDiagnosticConfig,
 } from '../types';
+import { extractJSON, findTextRange } from './llm-utils';
 
 /**
  * LLM-powered analyzer for semantic analysis
@@ -24,220 +25,6 @@ export class LLMAnalyzer {
     start: { line: 0, character: 0 },
     end: { line: 0, character: 1 },
   };
-
-  /**
-   * Extract JSON from an LLM response that may be wrapped in markdown code fences
-   * or contain leading/trailing non-JSON text.
-   */
-  private extractJSON<T>(text: string): T {
-    // Try several extraction strategies because model output may include fences,
-    // pre/post prose, or slightly invalid JSON.
-    const candidates = this.buildJSONCandidates(text);
-    let lastError: unknown;
-
-    for (const candidate of candidates) {
-      const normalized = candidate.trim();
-      if (!normalized) {
-        continue;
-      }
-
-      try {
-        return JSON.parse(normalized) as T;
-      } catch (error) {
-        lastError = error;
-      }
-
-      // If strict parse fails, run a conservative repair pass for common model mistakes.
-      const repaired = this.repairCommonJSONIssues(normalized);
-      if (repaired !== normalized) {
-        try {
-          return JSON.parse(repaired) as T;
-        } catch (error) {
-          lastError = error;
-        }
-      }
-    }
-
-    throw (lastError instanceof Error ? lastError : new Error('JSON parse error'));
-  }
-
-  private buildJSONCandidates(text: string): string[] {
-    const trimmed = text.trim();
-    const candidates: string[] = [];
-
-    const pushCandidate = (value: string | undefined): void => {
-      const normalized = value?.trim();
-      if (!normalized || candidates.includes(normalized)) {
-        return;
-      }
-      candidates.push(normalized);
-    };
-
-    pushCandidate(trimmed);
-
-    // Collect all fenced blocks and prefer JSON-labeled blocks first.
-    const jsonFenced: string[] = [];
-    const genericFenced: string[] = [];
-    // Match fenced code blocks and capture an optional language tag plus the block contents.
-    const fencePattern = /```([a-zA-Z0-9_-]+)?\s*\n?([\s\S]*?)```/g;
-    let match: RegExpExecArray | null;
-    while ((match = fencePattern.exec(trimmed)) !== null) {
-      const language = (match[1] || '').toLowerCase();
-      const content = match[2]?.trim();
-      if (!content) {
-        continue;
-      }
-
-      if (language === 'json') {
-        jsonFenced.push(content);
-      } else {
-        genericFenced.push(content);
-      }
-    }
-
-    for (const block of jsonFenced) {
-      pushCandidate(block);
-    }
-    for (const block of genericFenced) {
-      pushCandidate(block);
-    }
-
-    // Also derive a balanced object slice so trailing guidance text does not break parsing.
-    const snapshot = candidates.slice();
-    for (const candidate of snapshot) {
-      pushCandidate(this.extractBalancedJSONObject(candidate));
-    }
-
-    return candidates;
-  }
-
-  private extractBalancedJSONObject(value: string): string | undefined {
-    const start = value.indexOf('{');
-    if (start === -1) {
-      return undefined;
-    }
-
-    // Track braces while honoring JSON strings/escapes to find the first complete object.
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-
-    for (let i = start; i < value.length; i++) {
-      const ch = value[i];
-
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-
-      if (ch === '\\') {
-        escaped = true;
-        continue;
-      }
-
-      if (ch === '"') {
-        inString = !inString;
-        continue;
-      }
-
-      if (inString) {
-        continue;
-      }
-
-      if (ch === '{') {
-        depth += 1;
-        continue;
-      }
-
-      if (ch === '}') {
-        depth -= 1;
-        if (depth === 0) {
-          return value.slice(start, i + 1);
-        }
-      }
-    }
-
-    return undefined;
-  }
-
-  private repairCommonJSONIssues(input: string): string {
-    let result = input
-      .replace(/\uFEFF/g, '')
-      // Replace curly double quotes with straight quotes so JSON stays valid.
-      .replace(/[\u201C\u201D]/g, '"')
-      // Replace curly single quotes with straight apostrophes.
-      .replace(/[\u2018\u2019]/g, "'")
-      // Strip block comments that are valid in JSONC but not strict JSON.
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      // Strip line comments that are valid in JSONC but not strict JSON.
-      .replace(/(^|\s)\/\/.*$/gm, '')
-      // Remove trailing commas before closing objects or arrays.
-      .replace(/,\s*([}\]])/g, '$1');
-
-    // Best-effort recovery for a frequent model mistake: missing comma between values.
-    // We only insert where the parser error position is between two value-like tokens.
-    for (let i = 0; i < 4; i++) {
-      const position = this.getParseErrorPosition(result);
-      if (position === undefined || position <= 0 || position >= result.length) {
-        break;
-      }
-
-      const previous = this.findPreviousNonWhitespace(result, position - 1);
-      const current = this.findNextNonWhitespace(result, position);
-      if (previous === undefined || current === undefined) {
-        break;
-      }
-
-      // The previous character should look like the end of a JSON value.
-      const valueEnding = /[\]"0-9eElrtf}]/.test(previous);
-      // The next character should look like the start of a new JSON value.
-      const valueStarting = /[[{"\-0-9tfn]/.test(current);
-      if (!valueEnding || !valueStarting) {
-        break;
-      }
-
-      result = result.slice(0, position) + ',' + result.slice(position);
-    }
-
-    return result;
-  }
-
-  private getParseErrorPosition(text: string): number | undefined {
-    try {
-      JSON.parse(text);
-      return undefined;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      // Extract the character offset from Node's JSON.parse error text.
-      const match = message.match(/position\s+(\d+)/i);
-      if (!match) {
-        return undefined;
-      }
-
-      const parsed = Number.parseInt(match[1], 10);
-      return Number.isFinite(parsed) ? parsed : undefined;
-    }
-  }
-
-  private findPreviousNonWhitespace(text: string, index: number): string | undefined {
-    for (let i = index; i >= 0; i--) {
-      // Skip past whitespace until we find the previous non-whitespace character.
-      if (!/\s/.test(text[i])) {
-        return text[i];
-      }
-    }
-    return undefined;
-  }
-
-  private findNextNonWhitespace(text: string, index: number): string | undefined {
-    for (let i = index; i < text.length; i++) {
-      // Skip past whitespace until we find the next non-whitespace character.
-      if (!/\s/.test(text[i])) {
-        return text[i];
-      }
-    }
-    return undefined;
-  }
 
   private formatError(error: unknown): string {
     if (error instanceof Error) return error.message;
@@ -278,7 +65,7 @@ export class LLMAnalyzer {
   }
 
   private getRangeFromText(doc: TextDocument, text: string): AnalysisResult['range'] {
-    const { line, startChar, endChar } = this.findTextRange(doc, text);
+    const { line, startChar, endChar } = findTextRange(doc, text);
     return {
       start: { line, character: startChar },
       end: { line, character: endChar },
@@ -536,7 +323,7 @@ IMPORTANT:
     const response = await this.callLLM(doc.uri, prompt);
     const results: AnalysisResult[] = [];
     try {
-      const parsed = this.extractJSON<LLMCombinedAnalysisResponse>(response);
+      const parsed = extractJSON<LLMCombinedAnalysisResponse>(response);
       this.processContradictions(doc, parsed, results);
       this.processAmbiguity(doc, parsed, results);
       this.processPersona(doc, parsed, results);
@@ -553,8 +340,8 @@ IMPORTANT:
 
   private processContradictions(doc: TextDocument, parsed: LLMCombinedAnalysisResponse, results: AnalysisResult[]): void {
     for (const c of parsed.contradictions || []) {
-      const primaryRange = this.findTextRange(doc, c.instruction1);
-      const relatedRange = this.findTextRange(doc, c.instruction2);
+      const primaryRange = findTextRange(doc, c.instruction1);
+      const relatedRange = findTextRange(doc, c.instruction2);
 
       results.push(this.createDiagnostic(doc, {
         code: 'contradiction',
@@ -732,7 +519,7 @@ If no conflicts found, return {"conflicts": []}`;
     const results: AnalysisResult[] = [];
 
     try {
-      const parsed = this.extractJSON<{ conflicts?: LLMCombinedAnalysisResponse['composition_conflicts'] }>(response);
+      const parsed = extractJSON<{ conflicts?: LLMCombinedAnalysisResponse['composition_conflicts'] }>(response);
       for (const conflict of parsed.conflicts || []) {
         results.push(this.createDiagnostic(doc, {
           code: 'composition-conflict',
@@ -783,38 +570,6 @@ If no conflicts found, return {"conflicts": []}`;
     }
 
     return results;
-  }
-
-  /**
-   * Find the location of a piece of text in the document, returning line and column offsets.
-   */
-  private findTextRange(doc: TextDocument, text: string): { line: number; startChar: number; endChar: number } {
-    const lines = this.getLines(doc);
-    if (!text) return { line: 0, startChar: 0, endChar: lines[0]?.length || 0 };
-
-    const lowerText = text.toLowerCase();
-
-    // Exact substring match
-    for (let i = 0; i < lines.length; i++) {
-      const col = lines[i].toLowerCase().indexOf(lowerText);
-      if (col !== -1) {
-        return { line: i, startChar: col, endChar: col + text.length };
-      }
-    }
-
-    // Partial word match — find the best line and highlight the matched word
-    const words = lowerText.split(/\s+/).filter(w => w.length > 3).slice(0, 5);
-    for (let i = 0; i < lines.length; i++) {
-      const lowerLine = lines[i].toLowerCase();
-      for (const word of words) {
-        const col = lowerLine.indexOf(word);
-        if (col !== -1) {
-          return { line: i, startChar: col, endChar: col + word.length };
-        }
-      }
-    }
-
-    return { line: 0, startChar: 0, endChar: lines[0]?.length || 0 };
   }
 
   /**


### PR DESCRIPTION
## Summary

Extract `extractJSON` and `findTextRange` from `LLMAnalyzer` into a sibling module `src/analyzers/llm-utils.ts` as pure exported functions.

## Motivation

Both helpers had no `this` access — they were pure functions trapped in the class. Because they were `private`, the unit tests had to reach in via `as any` (and recently `as unknown as { ... }`) casts to exercise them. Pulling them out:

- Lets tests import them directly — zero casts, no private-access workaround.
- Restores the real `extractJSON<T>` generic signature in tests (the `as unknown as { ... }` workaround had to drop `<T>`).
- Shrinks `LLMAnalyzer` by ~45 lines without changing any behavior.

## Changes

- **New:** `src/analyzers/llm-utils.ts` — exports `extractJSON<T>` and `findTextRange`.
- **Modified:** `src/analyzers/llm.ts` — imports the helpers, removes the two private methods, switches all 12 call sites from `this.X(...)` to `X(...)`.
- **Modified:** `src/__tests__/llm.test.ts` — imports helpers directly, removes both `as unknown as { ... }` casts and the `extract`/`find` aliases.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean (no `@typescript-eslint/no-explicit-any` warnings)
- [x] `npm test` — 23/23 pass
- [x] No behavior change verified — same call signatures, same return values, only the location of the function definitions moved.