### PR TITLE
removing the commands from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,16 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "chatCustomizationsEvaluations.analyzePromptFromCustomization",
+          "when": "false"
+        },
+        {
+          "command": "chatCustomizationsEvaluations.wazaRunEvalFromFile",
+          "when": "false"
+        }
+      ],
       "editor/content": [
         {
           "command": "chatCustomizationsEvaluations.analyzePrompt",


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-chat-customizations-evaluation/issues/103