### PR TITLE
feat: suggestion quick fixes, hover, and settings (no extra LLM call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An extension for analyzing and improving AI prompt files. Works with `.prompt.md
 - **Editor Title Bar** — Analyze Prompt button appears when editing prompt files
 - **Command Palette** — `Chat Customizations Evaluations: Analyze Prompt` command
 - **Problems Panel** — All diagnostics appear in the standard VS Code Problems panel with precise line and column locations
+- **Suggestion Quick Fixes** — Diagnostics that include a suggestion offer instant actions (no extra LLM call) to copy the suggestion or insert it as a comment, and show it on hover
 
 ## Supported File Types
 
@@ -69,6 +70,8 @@ You can also trigger analysis from Copilot Chat with the slash command `/analyze
 | `chatCustomizationsEvaluations.trace.server` | `off` | Trace communication between VS Code and the language server |
 | `chatCustomizationsEvaluations.customDiagnostics` | `[]` | Array of custom diagnostic objects with `name` and `description` fields |
 | `chatCustomizationsEvaluations.waza.command` | `waza` | Command used to run waza (for example `/usr/local/bin/waza`) |
+| `chatCustomizationsEvaluations.suggestions.showQuickFixes` | `true` | Show quick fixes (copy suggestion, insert as comment) for diagnostics that include a suggestion |
+| `chatCustomizationsEvaluations.suggestions.showHover` | `true` | Show the suggestion text on hover for diagnostics that include a suggestion |
 
 ### Telemetry
 

--- a/client/package.json
+++ b/client/package.json
@@ -69,6 +69,16 @@
           "type": "string",
           "default": "claude-sonnet-4.6",
           "description": "Model to use for analysis (e.g., claude-sonnet-4.6, gpt-4o, gpt-4.1, etc). Defaults to claude-sonnet-4.6."
+        },
+        "chatCustomizationsEvaluations.suggestions.showQuickFixes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show quick fixes (copy suggestion, insert as comment) for diagnostics that include a suggestion."
+        },
+        "chatCustomizationsEvaluations.suggestions.showHover": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the suggestion text on hover for diagnostics that include a suggestion."
         }
       }
     },
@@ -99,7 +109,8 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "lint": "eslint src --ext ts"
+    "lint": "eslint src --ext ts",
+    "test": "cd .. && vitest run client/src/__tests__"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/client/src/__tests__/suggestionUtils.test.ts
+++ b/client/src/__tests__/suggestionUtils.test.ts
@@ -29,6 +29,10 @@ describe('getDiagnosticSuggestion', () => {
   it('returns undefined when the suggestion equals the message (redundant)', () => {
     expect(getDiagnosticSuggestion({ message: 'Same text', data: '  Same text ' })).toBeUndefined();
   });
+
+  it('returns undefined when the suggestion only differs from the message by whitespace', () => {
+    expect(getDiagnosticSuggestion({ message: 'Same text', data: 'Same\n  text' })).toBeUndefined();
+  });
 });
 
 describe('truncateSuggestionForLabel', () => {

--- a/client/src/__tests__/suggestionUtils.test.ts
+++ b/client/src/__tests__/suggestionUtils.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCopySuggestionLabel,
+  formatSuggestionComment,
+  getDiagnosticSuggestion,
+  truncateSuggestionForLabel,
+  SUGGESTION_LABEL_MAX_LENGTH,
+} from '../suggestionUtils';
+
+describe('getDiagnosticSuggestion', () => {
+  it('returns the trimmed suggestion when data is a non-empty string', () => {
+    expect(getDiagnosticSuggestion({ message: 'Problem', data: '  Do X instead  ' })).toBe('Do X instead');
+  });
+
+  it('returns undefined when data is missing', () => {
+    expect(getDiagnosticSuggestion({ message: 'Problem' })).toBeUndefined();
+  });
+
+  it('returns undefined when data is not a string', () => {
+    expect(getDiagnosticSuggestion({ message: 'Problem', data: 42 })).toBeUndefined();
+    expect(getDiagnosticSuggestion({ message: 'Problem', data: { x: 1 } })).toBeUndefined();
+  });
+
+  it('returns undefined when data is empty or whitespace only', () => {
+    expect(getDiagnosticSuggestion({ message: 'Problem', data: '' })).toBeUndefined();
+    expect(getDiagnosticSuggestion({ message: 'Problem', data: '   ' })).toBeUndefined();
+  });
+
+  it('returns undefined when the suggestion equals the message (redundant)', () => {
+    expect(getDiagnosticSuggestion({ message: 'Same text', data: '  Same text ' })).toBeUndefined();
+  });
+});
+
+describe('truncateSuggestionForLabel', () => {
+  it('collapses whitespace and leaves short text unchanged', () => {
+    expect(truncateSuggestionForLabel('Split   into\ntwo steps')).toBe('Split into two steps');
+  });
+
+  it('truncates long text with an ellipsis at the configured length', () => {
+    const long = 'x'.repeat(SUGGESTION_LABEL_MAX_LENGTH + 20);
+    const result = truncateSuggestionForLabel(long);
+    expect(result.length).toBe(SUGGESTION_LABEL_MAX_LENGTH);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('respects a custom max length', () => {
+    expect(truncateSuggestionForLabel('abcdefghij', 5)).toBe('abcd…');
+  });
+
+  it('keeps very small max lengths within the requested bound', () => {
+    expect(truncateSuggestionForLabel('abcdefghij', 1)).toBe('…');
+    expect(truncateSuggestionForLabel('abcdefghij', 0)).toBe('');
+    expect(truncateSuggestionForLabel('abcdefghij', -1)).toBe('');
+  });
+});
+
+describe('buildCopySuggestionLabel', () => {
+  it('wraps a previewed suggestion in quotes with the default prefix', () => {
+    expect(buildCopySuggestionLabel('Be concise')).toBe('Copy suggestion: "Be concise"');
+  });
+
+  it('honors a custom prefix', () => {
+    expect(buildCopySuggestionLabel('Be concise', 'Apply')).toBe('Apply: "Be concise"');
+  });
+
+  it('escapes quotes in the suggestion preview', () => {
+    expect(buildCopySuggestionLabel('Use "clear" phrasing')).toBe('Copy suggestion: "Use \\"clear\\" phrasing"');
+  });
+});
+
+describe('formatSuggestionComment', () => {
+  it('wraps the suggestion in an HTML comment on a single line', () => {
+    expect(formatSuggestionComment('Rewrite this\nas one step')).toBe('<!-- suggestion: Rewrite this as one step -->');
+  });
+
+  it('neutralizes double dashes that would break the comment', () => {
+    expect(formatSuggestionComment('use -- as a separator')).toBe('<!-- suggestion: use - as a separator -->');
+  });
+
+  it('strips trailing hyphens from the comment payload', () => {
+    expect(formatSuggestionComment('finish with a divider ---')).toBe('<!-- suggestion: finish with a divider -->');
+  });
+});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,10 +14,18 @@ import {
   registerWazaCommands,
 } from './waza/waza';
 import {
-  ACTION_ANALYZE_AGAIN, ACTION_FIX_DIAGNOSTICS, NON_FIXABLE_DIAGNOSTIC_CODES,
+  ACTION_ANALYZE_AGAIN, ACTION_COPY_SUGGESTION, ACTION_FIX_DIAGNOSTICS, ACTION_INSERT_SUGGESTION_COMMENT,
+  MESSAGE_NO_SUGGESTION_TO_COPY,
+  MESSAGE_SUGGESTION_COPIED,
+  NON_FIXABLE_DIAGNOSTIC_CODES,
   TELEMETRY_AUTH_TOKEN_ENV,
   TELEMETRY_ENDPOINT_ENV
 } from './strings';
+import {
+  buildCopySuggestionLabel,
+  formatSuggestionComment,
+  getDiagnosticSuggestion,
+} from './suggestionUtils';
 import type {
   AnalyzeRequest, CustomDiagnosticConfig, LLMProxyRequest,
   LLMProxyResponse,
@@ -30,6 +38,19 @@ import { ExtensionTelemetrySender } from './telemetry';
 const LLMRequestType = new RequestType<LLMProxyRequest, LLMProxyResponse, void>('chatCustomizationsEvaluations/llmRequest');
 const NON_FIXABLE_DIAGNOSTIC_CODE_SET = new Set<string>(NON_FIXABLE_DIAGNOSTIC_CODES);
 type AnalysisSnapshot = Awaited<ReturnType<AnalysisCoordinator['getCurrentAnalysisSnapshot']>>;
+
+/** File schemes/languages this extension analyzes; shared by the language client, code actions, and hovers. */
+const CUSTOMIZATION_DOCUMENT_SELECTOR: vscode.DocumentSelector = [
+  { scheme: 'file', language: 'prompt' },
+  { scheme: 'file', language: 'chatagent' },
+  { scheme: 'file', language: 'skill' },
+  { scheme: 'file', language: 'instructions' },
+  { scheme: 'file', language: 'markdown', pattern: '**/AGENTS.md' },
+  { scheme: 'vscode-userdata', language: 'prompt' },
+  { scheme: 'vscode-userdata', language: 'chatagent' },
+  { scheme: 'vscode-userdata', language: 'skill' },
+  { scheme: 'vscode-userdata', language: 'instructions' },
+];
 
 class ExtensionRuntime {
 
@@ -136,17 +157,7 @@ class ExtensionRuntime {
 
   private createClientOptions(): LanguageClientOptions {
     return {
-      documentSelector: [
-        { scheme: 'file', language: 'prompt' },
-        { scheme: 'file', language: 'chatagent' },
-        { scheme: 'file', language: 'skill' },
-        { scheme: 'file', language: 'instructions' },
-        { scheme: 'file', language: 'markdown', pattern: '**/AGENTS.md' },
-        { scheme: 'vscode-userdata', language: 'prompt' },
-        { scheme: 'vscode-userdata', language: 'chatagent' },
-        { scheme: 'vscode-userdata', language: 'skill' },
-        { scheme: 'vscode-userdata', language: 'instructions' },
-      ],
+      documentSelector: CUSTOMIZATION_DOCUMENT_SELECTOR as LanguageClientOptions['documentSelector'],
       synchronize: {
         fileEvents: [
           vscode.workspace.createFileSystemWatcher('**/*{prompt.md, agent.md, instructions.md, SKILL.md, AGENTS.md}')
@@ -203,29 +214,54 @@ class ExtensionRuntime {
   }
 
   private registerCodeActionProvider(context: vscode.ExtensionContext): void {
-    const documentSelector: vscode.DocumentSelector = [
-      { scheme: 'file', language: 'prompt' },
-      { scheme: 'file', language: 'chatagent' },
-      { scheme: 'file', language: 'skill' },
-      { scheme: 'file', language: 'instructions' },
-      { scheme: 'file', language: 'markdown', pattern: '**/AGENTS.md' },
-      { scheme: 'vscode-userdata', language: 'prompt' },
-      { scheme: 'vscode-userdata', language: 'chatagent' },
-      { scheme: 'vscode-userdata', language: 'skill' },
-      { scheme: 'vscode-userdata', language: 'instructions' },
-    ];
-
     this.outputChannel.appendLine('[Code Actions] Registering code action provider');
     context.subscriptions.push(
-      vscode.languages.registerCodeActionsProvider(documentSelector, {
+      vscode.languages.registerCodeActionsProvider(CUSTOMIZATION_DOCUMENT_SELECTOR, {
         provideCodeActions: (document, range, context) => this.provideCodeActions(document, range, context),
       }, {
         providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
       }),
+      vscode.languages.registerHoverProvider(CUSTOMIZATION_DOCUMENT_SELECTOR, {
+        provideHover: (document, position) => this.provideSuggestionHover(document, position),
+      }),
     );
   }
 
-  private provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext): vscode.CodeAction[] {
+  private isSuggestionFeatureEnabled(key: 'showQuickFixes' | 'showHover'): boolean {
+    return vscode.workspace
+      .getConfiguration('chatCustomizationsEvaluations.suggestions')
+      .get<boolean>(key, true);
+  }
+
+  private provideSuggestionHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | undefined {
+    if (!this.isSuggestionFeatureEnabled('showHover')) {
+      return undefined;
+    }
+    const suggestions: string[] = [];
+    for (const diagnostic of this.getExtensionDiagnostics(document.uri)) {
+      if (!diagnostic.range.contains(position)) {
+        continue;
+      }
+      const suggestion = getDiagnosticSuggestion(diagnostic);
+      if (suggestion) {
+        suggestions.push(suggestion);
+      }
+    }
+    if (suggestions.length === 0) {
+      return undefined;
+    }
+
+    const markdown = new vscode.MarkdownString();
+    markdown.isTrusted = false;
+    for (const suggestion of suggestions) {
+      markdown.appendMarkdown('**Suggestion:**\n\n');
+      markdown.appendCodeblock(suggestion);
+      markdown.appendMarkdown('\n\n');
+    }
+    return new vscode.Hover(markdown);
+  }
+
+  private provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, _context: vscode.CodeActionContext): vscode.CodeAction[] {
     const allDiagnostics = this.getExtensionDiagnostics(document.uri);
     const fixableDiagnostics = allDiagnostics.filter(
       d => !this.isNonFixableDiagnostic(d) && this.rangesOverlap(d.range, range),
@@ -235,16 +271,54 @@ class ExtensionRuntime {
       return [];
     }
 
-    return fixableDiagnostics.map(diagnostic => {
-      const action = new vscode.CodeAction(ACTION_FIX_DIAGNOSTICS, vscode.CodeActionKind.QuickFix);
-      action.diagnostics = [diagnostic];
-      action.command = {
+    const actions: vscode.CodeAction[] = [];
+    for (const diagnostic of fixableDiagnostics) {
+      const fixAction = new vscode.CodeAction(ACTION_FIX_DIAGNOSTICS, vscode.CodeActionKind.QuickFix);
+      fixAction.diagnostics = [diagnostic];
+      fixAction.command = {
         command: 'chatCustomizationsEvaluations.fixDiagnostics',
         title: ACTION_FIX_DIAGNOSTICS,
         arguments: [[diagnostic]],
       };
-      return action;
-    });
+      actions.push(fixAction);
+
+      // When the diagnostic already carries a suggestion (server puts it in `data`),
+      // offer instant actions that apply it without another LLM round-trip.
+      const suggestion = this.isSuggestionFeatureEnabled('showQuickFixes')
+        ? getDiagnosticSuggestion(diagnostic)
+        : undefined;
+      if (suggestion) {
+        const copyAction = new vscode.CodeAction(buildCopySuggestionLabel(suggestion), vscode.CodeActionKind.QuickFix);
+        copyAction.diagnostics = [diagnostic];
+        copyAction.command = {
+          command: 'chatCustomizationsEvaluations.copySuggestion',
+          title: ACTION_COPY_SUGGESTION,
+          arguments: [suggestion],
+        };
+        actions.push(copyAction);
+
+        const insertAction = new vscode.CodeAction(ACTION_INSERT_SUGGESTION_COMMENT, vscode.CodeActionKind.QuickFix);
+        insertAction.diagnostics = [diagnostic];
+        insertAction.edit = this.buildInsertSuggestionCommentEdit(document, diagnostic, suggestion);
+        actions.push(insertAction);
+      }
+    }
+    return actions;
+  }
+
+  private buildInsertSuggestionCommentEdit(
+    document: vscode.TextDocument,
+    diagnostic: vscode.Diagnostic,
+    suggestion: string,
+  ): vscode.WorkspaceEdit {
+    const line = document.lineAt(diagnostic.range.start.line);
+    const indent = line.text.slice(0, line.firstNonWhitespaceCharacterIndex);
+    const insertPosition = new vscode.Position(diagnostic.range.start.line, 0);
+    const commentLine = `${indent}${formatSuggestionComment(suggestion)}\n`;
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.insert(document.uri, insertPosition, commentLine);
+    return edit;
   }
 
   private registerWorkspaceHandlers(context: vscode.ExtensionContext): void {
@@ -396,8 +470,22 @@ class ExtensionRuntime {
       vscode.commands.registerCommand('chatCustomizationsEvaluations.analyzePromptUsingSlashCommand', async (obj) => this.handleAnalyzePromptUsingSlashCommand(obj)),
       vscode.commands.registerCommand('chatCustomizationsEvaluations.analyzePrompt', async (obj) => this.handleAnalyzePromptCommand(obj)),
       vscode.commands.registerCommand('chatCustomizationsEvaluations.fixDiagnostics', async (diagnostics?: vscode.Diagnostic[]) => this.handleFixDiagnosticsCommand(diagnostics)),
+      vscode.commands.registerCommand('chatCustomizationsEvaluations.copySuggestion', async (suggestion?: string) => this.handleCopySuggestionCommand(suggestion)),
       vscode.commands.registerCommand('chatCustomizationsEvaluations.analyzePromptFromCustomization', async (obj) => this.handleAnalyzePromptFromCustomizationCommand(obj)),
     );
+  }
+
+  private async handleCopySuggestionCommand(suggestion?: string): Promise<void> {
+    const text = suggestion?.trim();
+    if (!text) {
+      this.logTelemetryUsage('command/copySuggestion', { outcome: 'empty' });
+      void vscode.window.showWarningMessage(MESSAGE_NO_SUGGESTION_TO_COPY);
+      return;
+    }
+
+    await vscode.env.clipboard.writeText(text);
+    this.logTelemetryUsage('command/copySuggestion', { outcome: 'success' });
+    void vscode.window.showInformationMessage(MESSAGE_SUGGESTION_COPIED);
   }
 
   private async handleAnalyzePromptUsingSlashCommand(obj?: unknown): Promise<void> {

--- a/client/src/strings.ts
+++ b/client/src/strings.ts
@@ -1,8 +1,12 @@
 export const ACTION_SHOW_PROBLEMS = 'Show Problems';
 export const ACTION_FIX_DIAGNOSTICS = 'Implement suggestions';
+export const ACTION_COPY_SUGGESTION = 'Copy suggestion to clipboard';
+export const ACTION_INSERT_SUGGESTION_COMMENT = 'Insert suggestion as comment';
 export const ACTION_ANALYZE_AGAIN = 'Analyze Again';
 export const ACTION_INSTALL_WAZA_BINARY = 'Install Waza Binary';
 export const ACTION_OPEN_WAZA_USER_GUIDE = 'Open Waza User Guide';
+export const MESSAGE_NO_SUGGESTION_TO_COPY = 'No suggestion is available to copy for this diagnostic.';
+export const MESSAGE_SUGGESTION_COPIED = 'Suggestion copied to clipboard.';
 
 export const TELEMETRY_ENDPOINT_ENV = 'CHAT_CUSTOMIZATIONS_EVALUATIONS_TELEMETRY_ENDPOINT';
 export const TELEMETRY_AUTH_TOKEN_ENV = 'CHAT_CUSTOMIZATIONS_EVALUATIONS_TELEMETRY_AUTH_TOKEN';

--- a/client/src/suggestionUtils.ts
+++ b/client/src/suggestionUtils.ts
@@ -27,7 +27,9 @@ export function getDiagnosticSuggestion(diagnostic: SuggestionDiagnostic): strin
         return undefined;
     }
     const suggestion = diagnostic.data.trim();
-    if (!suggestion || suggestion === diagnostic.message.trim()) {
+    const normalizedSuggestion = suggestion.replace(/\s+/g, ' ');
+    const normalizedMessage = diagnostic.message.trim().replace(/\s+/g, ' ');
+    if (!suggestion || normalizedSuggestion === normalizedMessage) {
         return undefined;
     }
     return suggestion;

--- a/client/src/suggestionUtils.ts
+++ b/client/src/suggestionUtils.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure helpers for working with diagnostic suggestions.
+ *
+ * Deliberately free of any `vscode` import so the logic can be unit-tested
+ * without the editor runtime. The extension layer adapts `vscode.Diagnostic`
+ * onto the minimal {@link SuggestionDiagnostic} shape used here.
+ */
+
+/** Minimal shape needed to extract a suggestion from a diagnostic. */
+export interface SuggestionDiagnostic {
+    message: string;
+    /** Server attaches the suggestion string here (LSP Diagnostic.data). */
+    data?: unknown;
+}
+
+/** Max characters of suggestion text shown inline in a quick-fix label. */
+export const SUGGESTION_LABEL_MAX_LENGTH = 60;
+
+/**
+ * Return a usable suggestion string for a diagnostic, or undefined.
+ *
+ * A suggestion is usable only when it is a non-empty string that differs from
+ * the diagnostic's own message (otherwise the action would be redundant).
+ */
+export function getDiagnosticSuggestion(diagnostic: SuggestionDiagnostic): string | undefined {
+    if (typeof diagnostic.data !== 'string') {
+        return undefined;
+    }
+    const suggestion = diagnostic.data.trim();
+    if (!suggestion || suggestion === diagnostic.message.trim()) {
+        return undefined;
+    }
+    return suggestion;
+}
+
+/**
+ * Collapse whitespace and truncate a suggestion for display in a single-line
+ * label, appending an ellipsis when truncated.
+ */
+export function truncateSuggestionForLabel(suggestion: string, maxLength = SUGGESTION_LABEL_MAX_LENGTH): string {
+    const normalized = suggestion.replace(/\s+/g, ' ').trim();
+    if (maxLength <= 0) {
+        return '';
+    }
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+    if (maxLength === 1) {
+        return '…';
+    }
+    return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+/**
+ * Build the inline quick-fix label that previews the suggestion text, e.g.
+ * `Copy suggestion: "Split into two steps…"`.
+ */
+export function buildCopySuggestionLabel(suggestion: string, prefix = 'Copy suggestion'): string {
+    const preview = truncateSuggestionForLabel(suggestion).replace(/"/g, '\\"');
+    return `${prefix}: "${preview}"`;
+}
+
+/**
+ * Format a suggestion as an HTML comment for insertion above the flagged line.
+ * Multi-line suggestions are collapsed to a single line so the comment stays
+ * compact and never accidentally closes early.
+ */
+export function formatSuggestionComment(suggestion: string): string {
+    const oneLine = suggestion.replace(/\s+/g, ' ').trim().replace(/--+/g, '-').replace(/-+$/g, '').trimEnd();
+    return `<!-- suggestion: ${oneLine} -->`;
+}

--- a/package.json
+++ b/package.json
@@ -104,6 +104,16 @@
           "type": "boolean",
           "default": false,
           "description": "Automatically run an existing Waza eval after Implement suggestions applies improvements"
+        },
+        "chatCustomizationsEvaluations.suggestions.showQuickFixes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show quick fixes (copy suggestion, insert as comment) for diagnostics that include a suggestion."
+        },
+        "chatCustomizationsEvaluations.suggestions.showHover": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the suggestion text on hover for diagnostics that include a suggestion."
         }
       }
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ class ChatCustomizationsEvaluationServer {
   }
 
   private registerHandlers(): void {
-    this.connection.onInitialize((params: InitializeParams) => {
+    this.connection.onInitialize((_params: InitializeParams) => {
       const result: InitializeResult = {
         capabilities: {
           textDocumentSync: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,12 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/__tests__/**/*.test.ts'],
+    include: ['src/__tests__/**/*.test.ts', 'client/src/__tests__/**/*.test.ts'],
     globals: false,
     coverage: {
       provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/__tests__/**'],
+      include: ['src/**/*.ts', 'client/src/**/*.ts'],
+      exclude: ['src/__tests__/**', 'client/src/__tests__/**'],
     },
   },
 });


### PR DESCRIPTION
## Summary

Surfaces the suggestion that each diagnostic already carries (the server sets `result.suggestion` → LSP `Diagnostic.data`) directly in the editor, so users can act on it **without triggering another LLM round-trip**. Today the only quick fix re-calls the model; this adds instant, deterministic ways to use the suggestion that's already present.

## What's new

- **Quick fix — Copy suggestion to clipboard.** Label previews the suggestion text, e.g. `Copy suggestion: "Split into two steps…"`.
- **Quick fix — Insert suggestion as comment.** Inserts `<!-- suggestion: ... -->` above the flagged line via a reversible `WorkspaceEdit`, preserving indentation (and neutralizing `--` so the comment can't close early).
- **Hover provider.** Shows the suggestion as markdown for any diagnostic under the cursor.
- **Settings** (both default `true`):
  - `chatCustomizationsEvaluations.suggestions.showQuickFixes`
  - `chatCustomizationsEvaluations.suggestions.showHover`

## Implementation notes

- Pure, `vscode`-free logic (`getDiagnosticSuggestion`, label truncation, comment formatting) is extracted to `client/src/suggestionUtils.ts` so it is unit-testable without the editor runtime.
- The previously duplicated `documentSelector` is consolidated into a single shared `CUSTOMIZATION_DOCUMENT_SELECTOR` constant used by the language client, code actions, and the new hover provider.
- The `copySuggestion` command follows the existing `fixDiagnostics` pattern: an internal command invoked only from the code action, so no `contributes.commands` entry is required.
- New `client/src/__tests__/suggestionUtils.test.ts` (12 tests). Client tests now run through the root `vitest` config (and a convenience `test` script in `client/package.json`).
- README updated: new settings documented and the feature listed under Editor Integration.

## Testing

- `npm run build` — passes (server + client `tsc`).
- `npm run lint` — 0 errors.
- `npm test` — 46 passed (34 existing + 12 new).
