### PR TITLE
extension: require VS Code 1.118

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.118.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/microsoft/vscode-chat-customizations-evaluation"
   },
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.118.0"
   },
   "enabledApiProposals": [
     "chatSessionCustomizationProvider",


### PR DESCRIPTION
## Summary

- raise `engines.vscode` from `^1.90.0` to `^1.118.0`
- keep the root package-lock manifest metadata aligned

## Compatibility reason

The published extension ID is `ms-vscode.vscode-chat-customizations-evaluations`, and it requests the `chatSessionCustomizationProvider` and `contribEditorContentMenu` proposed APIs. The historical shipped-product audit in microsoft/vscode-engineering#3705 confirms that stable VS Code 1.117.0 does not authorize either requested proposal for this extension, while 1.118.0 is the first stable release that authorizes both. Because `^1.90.0` admits incompatible shipped products, the mandatory proposal compatibility gate would reject publishing; `^1.118.0` limits releases to the compatible range.

Both the stable and pre-release pipelines extend the shared `microsoft/vscode-engineering` publishing templates, and the pre-release manifest generator preserves the updated engine range and proposal metadata. microsoft/vscode-remote-release#11815 is a recent example of the same class of shipped extension/proposed-API compatibility failure that the mandatory gate is intended to prevent.

## Validation

- `npm exec --yes --package=@vscode/vsce -- npm run package`
- generated pre-release manifest assertion: extension ID, `^1.118.0`, and both proposals preserved
- proposed-API gate boundary check: 1.117.0 rejected both proposals; 1.118.0 passed
- proposed-API gate on the packaged VSIX: 29 admitted stable products through 1.135.0 passed
- `git diff --check`