### PR TITLE
Fix language client startup with a log output channel

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -51,6 +51,7 @@ class ExtensionRuntime {
     );
     context.subscriptions.push(this.outputChannel);
     const serverOptions = this.createServerOptions(context);
+    const clientOptions = this.createClientOptions();
     this.client = new LanguageClient(
       'chatCustomizationsEvaluations',
       'Chat Customizations Evaluations',

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -33,7 +33,7 @@ class ExtensionRuntime {
   private static readonly LLM_REQUEST_TIMEOUT_MS = 30_000;
 
   private client!: LanguageClient;
-  private outputChannel!: vscode.OutputChannel;
+  private outputChannel!: vscode.LogOutputChannel;
   private modelPicker!: ModelPicker;
   private extensionContext!: vscode.ExtensionContext;
   private analysisCoordinator!: AnalysisCoordinator;
@@ -45,7 +45,10 @@ class ExtensionRuntime {
 
   activate(context: vscode.ExtensionContext): void {
 
-    this.outputChannel = vscode.window.createOutputChannel('Chat Customizations Evaluations');
+    this.outputChannel = vscode.window.createOutputChannel(
+      'Chat Customizations Evaluations',
+      { log: true },
+    );
     const serverOptions = this.createServerOptions(context);
     const clientOptions = this.createClientOptions();
     this.client = new LanguageClient(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -49,8 +49,8 @@ class ExtensionRuntime {
       'Chat Customizations Evaluations',
       { log: true },
     );
+    context.subscriptions.push(this.outputChannel);
     const serverOptions = this.createServerOptions(context);
-    const clientOptions = this.createClientOptions();
     this.client = new LanguageClient(
       'chatCustomizationsEvaluations',
       'Chat Customizations Evaluations',

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ES2020"],
     "outDir": "./out",
     "rootDir": "./src",


### PR DESCRIPTION
Fixes #276
Fixes https://github.com/microsoft/vscode-chat-customizations-evaluation/issues/284

## Summary

`vscode-languageclient` 10.1.0 requires `LanguageClientOptions.outputChannel` to be a `vscode.LogOutputChannel`. The extension currently supplies a plain output channel, causing language-client startup to fail when it invokes log methods such as `.error()`.

This change creates the channel with `{ log: true }` and declares the stored channel as `vscode.LogOutputChannel`. The client TypeScript configuration now uses Node16 module resolution so the `vscode-languageclient` v10 package is compiled with its modern module declarations.

The regression was introduced in pre-release `v1.1.2026072818` when `vscode-languageclient` was upgraded to 10.1.0 by #274. Stable `v1.0.8` predates that dependency update.

## Validation

- `npm ci`
- `npm run compile`
- `npm run build`
- `npm test` (34 passed)
- `npm run lint` (passes; one existing unused-parameter warning in `client/src/waza/waza.ts:689`)